### PR TITLE
Fix typo in the template. s/retriving/retrieving/g

### DIFF
--- a/cmd/slave/slave.go
+++ b/cmd/slave/slave.go
@@ -267,12 +267,12 @@ func work(m *xrpc.Mission) (err error) {
 			reportProgress(m.Mid, status, string(buf.Bytes()))
 		})
 	}
-	reportProgress(m.Mid, models.ST_RETRIVING, "start get source code")
+	reportProgress(m.Mid, models.ST_RETRIEVING, "start get source code")
 	var done chan bool
-	done = newNotify(models.ST_RETRIVING, buffer)
+	done = newNotify(models.ST_RETRIEVING, buffer)
 	err = getsrc()
 	done <- true
-	reportProgress(m.Mid, models.ST_RETRIVING, string(buffer.Bytes()))
+	reportProgress(m.Mid, models.ST_RETRIEVING, string(buffer.Bytes()))
 	if err != nil {
 		log.Errorf("getsource err: %v", err)
 		return

--- a/models/task.go
+++ b/models/task.go
@@ -13,7 +13,7 @@ import (
 const (
 	ST_READY      = "ready"
 	ST_PENDING    = "pending"
-	ST_RETRIVING  = "retriving"
+	ST_RETRIVING  = "retrieving"
 	ST_BUILDING   = "building"
 	ST_PACKING    = "packing"
 	ST_PUBLISHING = "publishing"

--- a/models/task.go
+++ b/models/task.go
@@ -13,7 +13,7 @@ import (
 const (
 	ST_READY      = "ready"
 	ST_PENDING    = "pending"
-	ST_RETRIVING  = "retrieving"
+	ST_RETRIEVING  = "retrieving"
 	ST_BUILDING   = "building"
 	ST_PACKING    = "packing"
 	ST_PUBLISHING = "publishing"


### PR DESCRIPTION
Fix a tiny typo in the gobuild2 template. 
